### PR TITLE
fix(generator): adds missing '/' to lint-fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "eslint ./generators ./helpers",
-    "lint-fix": "eslint --fix ./generators .helpers",
+    "lint-fix": "eslint --fix ./generators ./helpers",
     "test": "nyc mocha ./generators/*/*.test.js ./helpers/**/*.test.js",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
Bugfix related to error on lint-fix script, which can't find `.helpers` directory (because it should be `./helpers`)