### PR TITLE
Add helper modules loader

### DIFF
--- a/generators/app/templates/src/app.js
+++ b/generators/app/templates/src/app.js
@@ -10,6 +10,7 @@ const override = require('koa-override-method');
 const assets = require('./assets');
 const mailer = require('./mailers');
 const routes = require('./routes');
+const helpers = require('./helpers');
 const orm = require('./models');
 
 // App constructor
@@ -26,6 +27,9 @@ app.keys = [
 
 // expose ORM through context's prototype
 app.context.orm = orm;
+
+// expose helpers through context's prototype
+app.context.helpers = helpers;
 
 /**
  * Middlewares

--- a/generators/app/templates/src/helpers/hello.js
+++ b/generators/app/templates/src/helpers/hello.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  // Variable :name must exist and determines the helper namespace
+  name: 'hello',
+  // Write your functions
+  sayHey: () => {
+    console.log('Hey'); // eslint-disable-line no-console
+  },
+  sayHo: () => {
+    console.log('Ho'); // eslint-disable-line no-console
+  },
+};

--- a/generators/app/templates/src/helpers/index.js
+++ b/generators/app/templates/src/helpers/index.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const basename = path.basename(module.filename);
+
+const helpers = {};
+
+fs
+  .readdirSync(__dirname)
+  .filter((file) => file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js')
+  .forEach((file) => {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    const helperModule = require(path.join(__dirname, file));
+    const { name, ...helperObject } = helperModule;
+    helpers[name] = helperObject;
+  });
+
+module.exports = helpers;

--- a/generators/app/templates/src/helpers/index.js
+++ b/generators/app/templates/src/helpers/index.js
@@ -10,8 +10,7 @@ fs
   .filter((file) => file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js')
   .forEach((file) => {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    const helperModule = require(path.join(__dirname, file));
-    const { name, ...helperObject } = helperModule;
+    const { name, ...helperObject } = require(path.join(__dirname, file));
     helpers[name] = helperObject;
   });
 

--- a/generators/app/templates/src/routes/hello.js
+++ b/generators/app/templates/src/routes/hello.js
@@ -4,6 +4,11 @@ const sendExampleEmail = require('../mailers/example');
 const router = new KoaRouter();
 
 router.get('hello', '/', async (ctx) => {
+  // Use helper functions
+  ctx.helpers.hello.sayHey();
+  ctx.helpers.hello.sayHo();
+
+  // Render view
   await ctx.render('hello/index', {
     nameUrl: (name) => ctx.router.url('hello.name', name),
     notice: ctx.flashMessage.notice,


### PR DESCRIPTION
# Feature: Add helper modules loader :wrench:

## Changes

Add a folder named `helpers` inside the template's `src` folder and an `index.js` that loads every other `.js` file of that folder into the application's context.

## Requirements

None, really :sparkles:

## Additional changes

Add an example of how to define a helper module and how to use the helpers within a route.